### PR TITLE
Implement versioning support in .htaccess

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -1,5 +1,34 @@
 RewriteEngine On
 
+# Extract version from the path: /v1.0.0/
+RewriteCond %{REQUEST_URI} ^/([^/]+)/?(index\.html)?$
+RewriteRule ^([^/]+)/?(index\.html)?$ - [E=VERSION:%1]
+
+# HTML (versioned)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteCond %{ENV:VERSION} !^$
+RewriteRule ^([^/]+)/?(index\.html)?$ https://aiaont.github.io/impactont/impactont.html?v=%{ENV:VERSION} [R=303,L]
+
+# JSON-LD (versioned)
+RewriteCond %{HTTP_ACCEPT} application/json [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteCond %{ENV:VERSION} !^$
+RewriteRule ^([^/]+)/?(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/impactont@%{ENV:VERSION}/impactont.jsonld [R=303,L]
+
+# Turtle (versioned)
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteCond %{ENV:VERSION} !^$
+RewriteRule ^([^/]+)/?(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/impactont@%{ENV:VERSION}/impactont.ttl [R=303,L]
+
+# RDF/XML (versioned)
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteCond %{ENV:VERSION} !^$
+RewriteRule ^([^/]+)/?(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/impactont@%{ENV:VERSION}/impactont.owl [R=303,L]
+
+# Fallback rules for non-versioned requests (root path)
 # HTML
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]


### PR DESCRIPTION
- Add version extraction from URL path (e.g., /v1.0.0/)
- Support versioned requests for all content types (HTML, JSON-LD, Turtle, RDF/XML)
- Maintain backward compatibility with non-versioned requests
- Versioned requests route to GitHub releases while non-versioned route to main branch
- Based on htaccessExample pattern for consistent versioning across ontologies